### PR TITLE
Timezone Offsets/Pretty Format

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,11 @@ var ReactDOM = require('react-dom')
 
 var TimezoneTracker = React.createClass({
   getInitialState: function() {
-    return {data: [{name: "Pat", location: "Ukraine", offset: -7}, {name: "Larry", location: "Cambodia", offset: 3}]}
+    return {data: [
+      {name: "Pat", location: "Ukraine", offset: 3}, 
+      {name: "Larry", location: "Cambodia", offset: 7},      
+      {name: "Haley", location: "Utah", offset: -7}
+    ]}
   },
   render: function () {
     return (
@@ -35,8 +39,10 @@ var TimezoneList = React.createClass({
     var timerInterval = setInterval(this.timer, 1000)
   },
   timer: function () {
-    d = new Date().getTime()
-    this.setState({date: d})
+    var d = new Date()
+    var localTimezoneOffset = d.getTimezoneOffset() * 60 * 1000
+    var adjustedDateTime = d.getTime() + localTimezoneOffset
+    this.setState({date: adjustedDateTime})
   },
   render: function () {
     var currentDate = this.state.date
@@ -60,14 +66,33 @@ var TimezoneList = React.createClass({
 
 var TimezoneTeamMember = React.createClass({
   formateDateTime: function () {
-    var adjustedDateTime = this.props.date + (this.props.offset * 1000 * 60 * 60)
+    var days = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
+    var months = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"]
+
+    var localDate = this.props.date
+    var adjustedDateTime = localDate + (this.props.offset * 1000 * 60 * 60)
     var adjustedDate = new Date(adjustedDateTime)
-    var formattedDateTime = adjustedDate.toString()
+
+    var thisDay = days[adjustedDate.getDay()]
+    var thisDate = adjustedDate.getDate()
+    var thisMonth = months[adjustedDate.getMonth()]
+
+    var thisHour = adjustedDate.getHours()
+    var thisMinute = adjustedDate.getMinutes()
+    if(thisMinute<10)thisMinute = "0" + thisMinute
+    var thisSecond = adjustedDate.getSeconds()
+    if(thisSecond<10)thisSecond = "0" + thisSecond
+    var formattedTime = thisHour + ":" + thisMinute + ":" + thisSecond
+
+    var formattedDateTime = thisDay + ", " + thisMonth + " " + thisDate + " - " + formattedTime
     return formattedDateTime
   },
   render: function () {
     return (
-      <div>{this.props.name} - {this.props.location} - {this.formateDateTime()}</div>
+      <div>
+        <h4>{this.props.name} - {this.props.location}</h4>
+        <p>{this.formateDateTime()}</p>
+      </div>
     )
   }
 })


### PR DESCRIPTION
Okay, "pretty" is an exaggeration, but it was:
<img width="429" alt="screen shot 2016-07-01 at 7 34 25 pm" src="https://cloud.githubusercontent.com/assets/3202211/16537815/45b5db7a-3fc3-11e6-9857-03c6e02a7cda.png">
And now it's at least redable: 
<img width="218" alt="screen shot 2016-07-01 at 7 33 32 pm" src="https://cloud.githubusercontent.com/assets/3202211/16537816/4c627046-3fc3-11e6-8726-9faf85653d6d.png">

This PR also takes timezone offsets into consideration, though they're added manually. 
